### PR TITLE
Fixed using dispatcher in QueueReceivedMessageHandler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "mockery/mockery": "^1.0",
         "mikey179/vfsstream": "^1.6",
         "umbrellio/code-style-php": "^1.0",
+        "symplify/easy-coding-standard":  "^9.3.15",
         "laravel/legacy-factories": "*",
         "php-coveralls/php-coveralls": "^2.1",
         "squizlabs/php_codesniffer": "^3.5"

--- a/src/Integration/Laravel/ReceivedMessageHandlers/QueueReceivedMessageHandler.php
+++ b/src/Integration/Laravel/ReceivedMessageHandlers/QueueReceivedMessageHandler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Umbrellio\TableSync\Integration\Laravel\ReceivedMessageHandlers;
 
-use Illuminate\Bus\Dispatcher;
+use Illuminate\Contracts\Bus\Dispatcher;
 use Umbrellio\TableSync\Integration\Laravel\Jobs\ReceiveMessage;
 use Umbrellio\TableSync\Messages\ReceivedMessage;
 use Umbrellio\TableSync\ReceivedMessageHandler;


### PR DESCRIPTION
Use contract of bus-dispatcher in QueueReceivedMessageHandler instead of concrete dispatcher.
Firstly, using interface is just preferred. And secondly, it produces problems if we want to extend bus-dispatcher.