### PR TITLE
Filter empty data

### DIFF
--- a/src/Integration/Laravel/Receive/Upserter/Upserter.php
+++ b/src/Integration/Laravel/Receive/Upserter/Upserter.php
@@ -21,7 +21,7 @@ class Upserter
     // todo via modern expressive not existing query builder
     public function upsert(MessageData $messageData, float $version): void
     {
-        if (empty($messageData->getData())) {
+        if (empty(array_filter($messageData->getData()))) {
             return;
         }
 


### PR DESCRIPTION
Добавила array_filter, для того чтоб проходила проверка на пустоту, в случае когда AdditionalDataHandler возвращает пустой массив. Это используется когда нужно фильтровать данные и записывать не все типы событий, так же отфильтровывать пустые массивы, которые будут приходить в батчах.