### PR TITLE
Filter empty data for destroyer

### DIFF
--- a/src/Integration/Laravel/Receive/Destroyer.php
+++ b/src/Integration/Laravel/Receive/Destroyer.php
@@ -13,7 +13,7 @@ class Destroyer
 {
     public function destroy(MessageData $message): void
     {
-        if (empty($message->getData())) {
+        if (empty(array_filter($message->getData()))) {
             return;
         }
 


### PR DESCRIPTION
Добавила array_filter, для того чтоб проходила проверка на пустоту для события destroy, в случае когда AdditionalDataHandler возвращает пустой массив. Это используется когда нужно фильтровать данные и записывать не все типы событий, так же отфильтровывать пустые массивы, которые будут приходить в батчах.