### PR TITLE
JSON formatter

### DIFF
--- a/src/Monolog/Formatter/JsonTableSyncFormatter.php
+++ b/src/Monolog/Formatter/JsonTableSyncFormatter.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umbrellio\TableSync\Monolog\Formatter;
+
+use Monolog\Utils;
+
+class JsonTableSyncFormatter extends TableSyncFormatter
+{
+    public function format(array $record)
+    {
+        $record = parent::format($record);
+        $formatted = [
+            'datetime' => $record['datetime'],
+            'message' => $record['message'],
+            'direction' => $record['direction'],
+            'routing' => $record['routing'],
+            'model' => $record['model'],
+            'event' => $record['event'],
+            'count' => count($record['attributes']),
+        ];
+
+        return Utils::jsonEncode($formatted, Utils::DEFAULT_JSON_FLAGS, true) . "\n";
+    }
+}

--- a/tests/unit/Logging/FormatterTest.php
+++ b/tests/unit/Logging/FormatterTest.php
@@ -7,6 +7,7 @@ namespace Umbrellio\TableSync\Tests\Unit\Logging;
 use InfluxDB\Point;
 use Umbrellio\TableSync\Messages\PublishMessage;
 use Umbrellio\TableSync\Monolog\Formatter\InfluxDBFormatter;
+use Umbrellio\TableSync\Monolog\Formatter\JsonTableSyncFormatter;
 use Umbrellio\TableSync\Monolog\Formatter\LineTableSyncFormatter;
 use Umbrellio\TableSync\Monolog\Formatter\TableSyncFormatter;
 use Umbrellio\TableSync\Rabbit\Config\PublishMessage as Config;
@@ -76,6 +77,18 @@ class FormatterTest extends UnitTestCase
         $this->assertIsArray($format);
         $this->assertContainsOnlyInstancesOf(Point::class, $format);
         $this->assertSame(['model', 'event', 'direction'], array_keys($format[0]->getTags()));
+    }
+
+    /**
+     * @test
+     */
+    public function jsonTableSyncFormat(): void
+    {
+        $jsonTableSyncFormatter = new JsonTableSyncFormatter();
+        $format = $jsonTableSyncFormatter->format($this->getDummyRecord());
+        $expected = '{"datetime":"datetime","message":"message","direction":"direction","routing":"routing_key","model":"model","event":"update","count":1}' . "\n";
+        $this->assertIsString($format);
+        $this->assertSame($expected, $format);
     }
 
     private function getDummyRecord(): array


### PR DESCRIPTION
JSON formatter is intended for the kubernetes environment where logs are stored in separated system (like opensearch).
This formatter is out of box solution for applications that are running in the kubernetes environment.

The fields "attributes" and "exception" was deleted from log because of sensitive purpose.