### PR TITLE
Disable exception suppression

### DIFF
--- a/src/Rabbit/Consumer.php
+++ b/src/Rabbit/Consumer.php
@@ -8,7 +8,6 @@ use Closure;
 use PhpAmqpLib\Message\AMQPMessage;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Throwable;
 
 class Consumer
 {
@@ -62,21 +61,13 @@ class Consumer
         $message = $this->messageBuilder->buildReceivedMessage($amqpMessage);
         $messageId = $amqpMessage->delivery_info['delivery_tag'];
 
-        try {
-            $this->config->handler()
-                ->handle($message);
-            $this->channelContainer->getChannel()
-                ->basic_ack($messageId);
-            $this->logger->info("Message #{$messageId} correctly handled", [
-                'direction' => 'receive',
-                'body' => $amqpMessage->getBody(),
-            ]);
-        } catch (Throwable $throwable) {
-            $this->logger->debug('Cannot handle message', [
-                'exception' => $throwable,
-            ]);
-            $this->channelContainer->getChannel()
-                ->basic_nack($messageId, false, true);
-        }
+        $this->config->handler()
+            ->handle($message);
+        $this->channelContainer->getChannel()
+            ->basic_ack($messageId);
+        $this->logger->info("Message #{$messageId} correctly handled", [
+            'direction' => 'receive',
+            'body' => $amqpMessage->getBody(),
+        ]);
     }
 }


### PR DESCRIPTION
Предлагаю убрать подавление исключений в консьюмере.
Основная идея: логика обработки исключений находится в `App\Exceptions\Handler`, логирование оных - в дефолтном `LOG_CHANNEL`. Кидая эксепшн из хендлера, я ожидаю, что он дойдёт до куда-то до туда и будет соответствующим образом обработан (допустим, отправлен в Sentry). Перенаправление же исключения в дебаг канала `table_sync` видится мне неочевидным и во многом нежелательным поведением.