### PR TITLE
Custom destroy attributes

### DIFF
--- a/src/Integration/Laravel/Contracts/SyncableModel.php
+++ b/src/Integration/Laravel/Contracts/SyncableModel.php
@@ -7,37 +7,42 @@ namespace Umbrellio\TableSync\Integration\Laravel\Contracts;
 interface SyncableModel
 {
     /**
-     * @var string
+     * @return string
      */
     public function getKeyName();
 
     /**
-     * @var string
+     * @return string
      */
     public function getKey();
 
     /**
-     * @var static|null
+     * @return static|null
      */
     public function fresh();
 
     /**
-     * @var array
+     * @return array
      */
     public function getTableSyncableAttributes();
 
     /**
-     * @var string
+     * @return array
+     */
+    public function getTableSyncableDeletedAttributes();
+
+    /**
+     * @return string
      */
     public function classForSync();
 
     /**
-     * @var bool
+     * @return bool
      */
     public function exists();
 
     /**
-     * @var string
+     * @return string
      */
     public function routingKey();
 }

--- a/src/Integration/Laravel/Contracts/SyncableModel.php
+++ b/src/Integration/Laravel/Contracts/SyncableModel.php
@@ -29,7 +29,7 @@ interface SyncableModel
     /**
      * @return array
      */
-    public function getTableSyncableDeletedAttributes();
+    public function getTableSyncableDestroyAttributes();
 
     /**
      * @return string

--- a/src/Integration/Laravel/Syncer.php
+++ b/src/Integration/Laravel/Syncer.php
@@ -50,7 +50,7 @@ class Syncer
     {
         $syncableAttributes = $model->exists() ?
             $model->getTableSyncableAttributes() :
-            $model->getTableSyncableDeletedAttributes();
+            $model->getTableSyncableDestroyAttributes();
 
         return array_merge($this->pkAttributes($model), $syncableAttributes);
     }

--- a/src/Integration/Laravel/Syncer.php
+++ b/src/Integration/Laravel/Syncer.php
@@ -48,11 +48,11 @@ class Syncer
 
     private function getSyncableAttributes(SyncableModel $model): array
     {
-        if (!$model->exists()) {
-            return $this->pkAttributes($model);
-        }
+        $syncableAttributes = $model->exists() ?
+            $model->getTableSyncableAttributes() :
+            $model->getTableSyncableDeletedAttributes();
 
-        return array_merge($this->pkAttributes($model), $model->getTableSyncableAttributes());
+        return array_merge($this->pkAttributes($model), $syncableAttributes);
     }
 
     private function needsPublishAttributes(SyncableModel $model, array $attributes): bool

--- a/src/Integration/Laravel/TableSyncable.php
+++ b/src/Integration/Laravel/TableSyncable.php
@@ -20,7 +20,7 @@ trait TableSyncable
         return $this->getAttributes();
     }
 
-    public function getTableSyncableDeletedAttributes(): array
+    public function getTableSyncableDestroyAttributes(): array
     {
         return [];
     }

--- a/src/Integration/Laravel/TableSyncable.php
+++ b/src/Integration/Laravel/TableSyncable.php
@@ -20,6 +20,11 @@ trait TableSyncable
         return $this->getAttributes();
     }
 
+    public function getTableSyncableDeletedAttributes(): array
+    {
+        return [];
+    }
+
     public function classForSync(): string
     {
         return static::class;

--- a/tests/functional/Laravel/Integration/Publishers/EnsureConsistencyPublisherTest.php
+++ b/tests/functional/Laravel/Integration/Publishers/EnsureConsistencyPublisherTest.php
@@ -24,7 +24,7 @@ class EnsureConsistencyPublisherTest extends LaravelTestCase
     {
         parent::setUp();
 
-        $this->spyPublisher = $this->makeSpyPublsiher();
+        $this->spyPublisher = $this->makeSpyPublisher();
 
         $this->app->bind(Publisher::class, function () {
             return $this->spyPublisher;

--- a/tests/functional/Laravel/Integration/TableSyncObserverTest.php
+++ b/tests/functional/Laravel/Integration/TableSyncObserverTest.php
@@ -22,7 +22,7 @@ class TableSyncObserverTest extends LaravelTestCase
     {
         parent::setUp();
 
-        $this->spyPublisher = $this->makeSpyPublsiher();
+        $this->spyPublisher = $this->makeSpyPublisher();
 
         $this->app->bind(Publisher::class, function () {
             return $this->spyPublisher;

--- a/tests/functional/Laravel/Traits/SpyPublisher.php
+++ b/tests/functional/Laravel/Traits/SpyPublisher.php
@@ -9,7 +9,7 @@ use Umbrellio\TableSync\Publisher;
 
 trait SpyPublisher
 {
-    protected function makeSpyPublsiher(): Publisher
+    protected function makeSpyPublisher(): Publisher
     {
         return new class() implements Publisher {
             public $messages;


### PR DESCRIPTION
Models can now send any attributes as a payload on destroy, not just the primary key